### PR TITLE
Remove arrow dataformat from module.yaml

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -19,7 +19,6 @@ spec:
           port: 80
           scheme: grpc
         protocol: fybrik-arrow-flight
-        dataformat: arrow
       supportedInterfaces:
         - source:
             protocol: s3
@@ -37,7 +36,6 @@ spec:
           port: 80
           scheme: grpc
         protocol: fybrik-arrow-flight
-        dataformat: arrow
       supportedInterfaces:
         - sink:
             protocol: s3


### PR DESCRIPTION
The `dataformat` field is optional and should not be specified with placeholders for protocols where this field is redundant.

Required by https://github.com/fybrik/fybrik/pull/1060