### PR TITLE
New structure of module arguments

### DIFF
--- a/helm/afm/files/conf.yaml
+++ b/helm/afm/files/conf.yaml
@@ -1,7 +1,7 @@
-app-uuid: {{ get .Values.labels "app.fybrik.io/app-uuid" | default "app-uuid-missing" }}
-{{ if .Values.read -}}
+app-uuid: {{ .Values.uuid | default "app-uuid-missing" }}
+{{ if .Values.assets -}}
 data:
-{{- range .Values.read }}
+{{- range .Values.assets }}
   - format: {{ .source.format }}
     name: {{ .assetID | quote }}
     {{- if .source.connection.s3 }}

--- a/helm/afm/values.sample.yaml
+++ b/helm/afm/values.sample.yaml
@@ -1,8 +1,8 @@
 # Try it with `helm install --generate-name --dry-run -f helm/afm/values.sample.yaml helm/afm`
 labels:
-  app.fybrik.io/app-uuid: 12345678
   name: 012d42539692bba841a7
   namespace: default
+uuid: 12345678
 assets:
 - assetID: "test1"
   source:

--- a/helm/afm/values.sample.yaml
+++ b/helm/afm/values.sample.yaml
@@ -3,7 +3,7 @@ labels:
   app.fybrik.io/app-uuid: 12345678
   name: 012d42539692bba841a7
   namespace: default
-read:
+assets:
 - assetID: "test1"
   source:
     connection:


### PR DESCRIPTION
Signed-off-by: Shlomit Koyfman <shlomitk@il.ibm.com>

This PR relates to https://github.com/fybrik/fybrik/pull/1295

Module arguments include:
- assets (instead of read)
- capability (currently unused)
- context (unused)
- labels (unused)
- selector (unused)
- uuid ( to replace extraction from the labels)