### PR TITLE
Raise exception when Vault credentials are missing.

### DIFF
--- a/afm/filesystems/vault.py
+++ b/afm/filesystems/vault.py
@@ -74,7 +74,7 @@ def get_credentials_from_vault(vault_credentials, datasetID):
                ForUser: True})
     credentials = get_raw_secret_from_vault(jwt, secret_path, vault_address, vault_auth, role, datasetID)
     if not credentials:
-        return None, None
+        raise ValueError("Vault credentials are missing")
     if 'access_key' in credentials and 'secret_key' in credentials:
         if credentials['access_key'] and credentials['secret_key']:
             return credentials['access_key'], credentials['secret_key']
@@ -87,4 +87,4 @@ def get_credentials_from_vault(vault_credentials, datasetID):
                              extra={DataSetID: datasetID, ForUser: True})
     logger.error("Expected both 'access_key' and 'secret_key' fields in vault secret",
                  extra={DataSetID: datasetID, ForUser: True})
-    return None, None
+    raise ValueError("Vault credentials are missing")


### PR DESCRIPTION
This PR raise exception when Vault credentials are missing.
Currently, when Vault credentials are missing Error message is printed to the module log but the execution of the module continues.

`{"error": "403: {'errors': ['permission denied']}", "DataSetID": "fybrik-notebook-sample/paysim-csv", "ForUser": true, "message": "vault authentication failed", "level": "ERROR", "caller": "vault.py:25", "funcName": "vault_jwt_auth", "time": "2022-03-02T08:42:46+0000", "app.fybrik.io/app-uuid": ""}
{"DataSetID": "fybrik-notebook-sample/paysim-csv", "ForUser": true, "message": "Empty vault authorization response", "level": "ERROR", "caller": "vault.py:34", "funcName": "get_raw_secret_from_vault", "time": "2022-03-02T08:42:46+0000", "app.fybrik.io/app-uuid": ""}
`

Closes #125 