### PR TITLE
Support not configuring a list of columns for a transformation.

### DIFF
--- a/afm/pep/base.py
+++ b/afm/pep/base.py
@@ -72,6 +72,8 @@ class Action:
             pyarrow.Schema: a new schema that matches transformed data
         """
         schema: pa.Schema = original
+        if not self.columns:
+            self.columns = schema.names
         columns = [column for column in self.columns if column in schema.names]
         for column in columns:
             field_index = schema.get_field_index(column)


### PR DESCRIPTION
For instance, if the HashRedact transformation configuration
does not include a set of columns, all columns would be transformed

Signed-off-by: Doron Chen <cdoron@il.ibm.com>