### PR TITLE
fix conf.yaml

### DIFF
--- a/helm/afm/files/conf.yaml
+++ b/helm/afm/files/conf.yaml
@@ -13,7 +13,7 @@ data:
       flight:
         endpoint_url: {{ index . "connection" "fybrik-arrow-flight" "hostname" }}
         port: {{ index . "connection" "fybrik-arrow-flight" "port" }}
-        flight_command: "{ \"asset\": \"{{ .assetID }}\" }"
+        flight_command: "{ \"asset\": \"{{ $asset.assetID }}\" }"
     {{- end }}
     {{- if index . "connection" "s3" }}
     path: "{{ .connection.s3.bucket }}/{{ .connection.s3.object_key }}"


### PR DESCRIPTION
Signed-off-by: Doron Chen <cdoron@il.ibm.com>

When changing the arrow-flight-module and the airbyte-module, there is a problem with the arrow-flight-module configuration:

```
connection:
      type: flight
      flight:
        endpoint_url: my-notebook-fybrik-notebook-sample-airbyte-module.fybrik-blueprints
        port: 80
        flight_command: "{ \"asset\": \"\" }"
```

The flight command does not include the asset name. Hopefully, this PR fixes this problem.