### PR TITLE
Update module.yaml write capability.

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -44,6 +44,9 @@ spec:
         - sink:
             protocol: s3
             dataformat: parquet
+        - sink:
+            protocol: s3
+            dataformat: csv
       actions:
         - name: RedactAction
         - name: RemoveAction


### PR DESCRIPTION
This PR updates module.yaml file with new capability to write csv files. CSV write is [supported ](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html) in arrow version v7 as the current code use. 